### PR TITLE
FEATURE: `Event` entity first implementation

### DIFF
--- a/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
+++ b/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
@@ -3,6 +3,7 @@ package com.br.hobbie.modules.event.domain.entities;
 import com.br.hobbie.modules.player.domain.entities.Player;
 import com.br.hobbie.modules.player.domain.entities.Tag;
 import com.br.hobbie.shared.core.errors.Either;
+import com.br.hobbie.shared.core.utils.CloneUtils;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -28,6 +29,7 @@ public class Event {
     private BigDecimal latitude;
     private BigDecimal longitude;
     private String thumbnail;
+    @Getter
     private boolean active = true;
 
 
@@ -74,7 +76,7 @@ public class Event {
     public void close() {
         if (active) {
             active = false;
-            participants.forEach(player -> player.removeEvent(this));
+            participants.forEach(player -> player.quitEvent(this));
         }
     }
 
@@ -96,5 +98,9 @@ public class Event {
                 ", admin=" + admin +
                 ", participants=" + participants +
                 '}';
+    }
+
+    public Player getAdmin() {
+        return CloneUtils.clone(Player.class, admin);
     }
 }

--- a/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
+++ b/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
@@ -1,0 +1,100 @@
+package com.br.hobbie.modules.event.domain.entities;
+
+import com.br.hobbie.modules.player.domain.entities.Player;
+import com.br.hobbie.modules.player.domain.entities.Tag;
+import com.br.hobbie.shared.core.errors.Either;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+public class Event {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+    @Getter
+    private String name;
+    @Getter
+    private String description;
+    private int capacity;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private String thumbnail;
+    private boolean active = true;
+
+
+    @ManyToMany
+    private Set<Tag> categories = new HashSet<>();
+
+    @OneToOne
+    private Player admin;
+
+    @OneToMany
+    private Set<Player> participants = new HashSet<>();
+
+
+    @Deprecated(since = "JPA only")
+    protected Event() {
+    }
+
+    public Event(String name, String description, int capacity, LocalDate date, LocalTime startTime, LocalTime endTime, BigDecimal latitude, BigDecimal longitude, String thumbnail, Set<Tag> categories, Player admin) {
+        this.name = name;
+        this.description = description;
+        this.capacity = capacity;
+        this.date = date;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.thumbnail = thumbnail;
+        this.categories = categories;
+        this.admin = admin;
+        this.admin.createEvent(this);
+        participants.add(admin);
+    }
+
+
+    public Either<RuntimeException, Void> addParticipant(Player player) {
+        if (participants.size() < capacity) {
+            participants.add(player);
+            return Either.right(null);
+        }
+
+        return Either.left(new RuntimeException("Event is full"));
+    }
+
+    public void close() {
+        if (active) {
+            active = false;
+            participants.forEach(player -> player.removeEvent(this));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", capacity=" + capacity +
+                ", date=" + date +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                ", latitude=" + latitude +
+                ", longitude=" + longitude +
+                ", thumbnail='" + thumbnail + '\'' +
+                ", active=" + active +
+                ", categories=" + categories +
+                ", admin=" + admin +
+                ", participants=" + participants +
+                '}';
+    }
+}

--- a/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
+++ b/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
@@ -67,6 +67,7 @@ public class Event {
     public Either<RuntimeException, Void> addParticipant(Player player) {
         if (participants.size() < capacity) {
             participants.add(player);
+            player.joinEvent(this);
             return Either.right(null);
         }
 

--- a/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
+++ b/src/main/java/com/br/hobbie/modules/event/domain/entities/Event.java
@@ -64,11 +64,13 @@ public class Event {
     }
 
 
-    public Either<RuntimeException, Void> addParticipant(Player player) {
+    public Either<RuntimeException, Boolean> addParticipant(Player player) {
         if (participants.size() < capacity) {
             participants.add(player);
-            player.joinEvent(this);
-            return Either.right(null);
+            var either = player.joinEvent(this);
+            if (either.isRight()) {
+                return Either.right(true);
+            }
         }
 
         return Either.left(new RuntimeException("Event is full"));
@@ -103,5 +105,9 @@ public class Event {
 
     public Player getAdmin() {
         return CloneUtils.clone(Player.class, admin);
+    }
+
+    public boolean capacityReached() {
+        return participants.size() == capacity;
     }
 }

--- a/src/main/java/com/br/hobbie/modules/player/domain/entities/Player.java
+++ b/src/main/java/com/br/hobbie/modules/player/domain/entities/Player.java
@@ -1,29 +1,41 @@
 package com.br.hobbie.modules.player.domain.entities;
 
+import com.br.hobbie.modules.event.domain.entities.Event;
+import com.br.hobbie.shared.core.errors.Either;
+import com.br.hobbie.shared.core.utils.CloneUtils;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
-public class Player {
+public class Player implements Comparable<Player> {
+
+    @ManyToMany(cascade = CascadeType.PERSIST)
+    private final Set<Tag> interests = new LinkedHashSet<>();
+    @Transient
+    private int internalId;
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
+    @Getter
     private String name;
-
     private String avatar;
-
     private BigDecimal matchLatitude;
     private BigDecimal matchLongitude;
     private LocalDate birthDate;
 
-    @ManyToMany(cascade = CascadeType.PERSIST)
-    private Set<Tag> interests = new LinkedHashSet<>();
+    @OneToOne(mappedBy = "admin")
+    private Event adminEvent;
+
+    @OneToMany
+    private Set<Event> participantEvents = new LinkedHashSet<>();
 
     /**
      * @deprecated (since = " JPA ") Constructor for JPA use only.
@@ -38,6 +50,7 @@ public class Player {
         this.matchLatitude = matchLatitude;
         this.matchLongitude = matchLongitude;
         this.birthDate = birthDate;
+        internalId = hashCode();
     }
 
     public void addInterest(Tag tag) {
@@ -49,4 +62,81 @@ public class Player {
                 .filter(tag -> !interests.contains(tag))
                 .forEach(interests::add);
     }
+
+    public Set<Tag> getInterests() {
+        return Set.copyOf(interests);
+    }
+
+    public Either<RuntimeException, Void> createEvent(Event event) {
+        if (adminEvent == null) {
+            adminEvent = event;
+            participantEvents.add(adminEvent);
+            return Either.right(null);
+        }
+
+        return Either.left(new RuntimeException("Player already has an event"));
+    }
+
+    public void closeEvent() {
+        adminEvent.close();
+    }
+
+    public Either<RuntimeException, Boolean> quitEvent(Event event) {
+        if (event.getAdmin().compareTo(this) == 0) {
+            return Either.left(new RuntimeException("Admin cannot quit event"));
+        }
+
+        participantEvents.remove(event);
+        return Either.right(true);
+    }
+
+    public Event getAdminEvent() {
+        // returns a copy of the event to avoid changes to the original event
+        return CloneUtils.clone(Event.class, adminEvent);
+    }
+
+    public List<Event> getParticipantEvents() {
+        // returns a copy of the participant events to remain immutable
+        return List.copyOf(participantEvents);
+    }
+
+
+    /**
+     * Compares this object with the specified object for order.  Returns a
+     * negative integer, zero, or a positive integer as this object is less
+     * than, equal to, or greater than the specified object.
+     *
+     * <p>The implementor must ensure {@link Integer#signum
+     * signum}{@code (x.compareTo(y)) == -signum(y.compareTo(x))} for
+     * all {@code x} and {@code y}.  (This implies that {@code
+     * x.compareTo(y)} must throw an exception if and only if {@code
+     * y.compareTo(x)} throws an exception.)
+     *
+     * <p>The implementor must also ensure that the relation is transitive:
+     * {@code (x.compareTo(y) > 0 && y.compareTo(z) > 0)} implies
+     * {@code x.compareTo(z) > 0}.
+     *
+     * <p>Finally, the implementor must ensure that {@code
+     * x.compareTo(y)==0} implies that {@code signum(x.compareTo(z))
+     * == signum(y.compareTo(z))}, for all {@code z}.
+     *
+     * @param o the object to be compared.
+     * @return a negative integer, zero, or a positive integer as this object
+     * is less than, equal to, or greater than the specified object.
+     * @throws NullPointerException if the specified object is null
+     * @throws ClassCastException   if the specified object's type prevents it
+     *                              from being compared to this object.
+     * @apiNote It is strongly recommended, but <i>not</i> strictly required that
+     * {@code (x.compareTo(y)==0) == (x.equals(y))}.  Generally speaking, any
+     * class that implements the {@code Comparable} interface and violates
+     * this condition should clearly indicate this fact.  The recommended
+     * language is "Note: this class has a natural ordering that is
+     * inconsistent with equals."
+     */
+    @Override
+    public int compareTo(Player o) {
+        return internalId - o.internalId;
+    }
+
+
 }

--- a/src/main/java/com/br/hobbie/modules/player/domain/entities/Player.java
+++ b/src/main/java/com/br/hobbie/modules/player/domain/entities/Player.java
@@ -86,6 +86,10 @@ public class Player implements Comparable<Player> {
             return Either.left(new RuntimeException("Admin cannot quit event"));
         }
 
+        if (!participantEvents.contains(event)) {
+            return Either.left(new RuntimeException("Player is not a participant of this event"));
+        }
+
         participantEvents.remove(event);
         return Either.right(true);
     }

--- a/src/main/java/com/br/hobbie/modules/player/domain/entities/Player.java
+++ b/src/main/java/com/br/hobbie/modules/player/domain/entities/Player.java
@@ -143,4 +143,15 @@ public class Player implements Comparable<Player> {
     }
 
 
+    public Either<RuntimeException, Boolean> joinEvent(Event event) {
+        if (!event.isActive()) return Either.left(new RuntimeException("Event is not active"));
+
+        if (event.capacityReached()) return Either.left(new RuntimeException("Event is full"));
+
+        if (adminEvent != null && adminEvent.equals(event))
+            return Either.left(new RuntimeException("Player is already admin of this event"));
+
+        participantEvents.add(event);
+        return Either.right(true);
+    }
 }

--- a/src/main/java/com/br/hobbie/modules/player/domain/entities/Tag.java
+++ b/src/main/java/com/br/hobbie/modules/player/domain/entities/Tag.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 import java.util.Objects;
 
@@ -31,6 +32,7 @@ public class Tag {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
+    @Getter
     private String name;
 
 
@@ -56,4 +58,5 @@ public class Tag {
     public int hashCode() {
         return Objects.hash(id, name);
     }
+
 }

--- a/src/main/java/com/br/hobbie/shared/core/utils/CloneUtils.java
+++ b/src/main/java/com/br/hobbie/shared/core/utils/CloneUtils.java
@@ -11,7 +11,7 @@ public class CloneUtils {
         try {
             var constructor = clazz.getDeclaredConstructor();
             constructor.setAccessible(true);
-            clone = clazz.cast(constructor.newInstance());
+            clone = constructor.newInstance();
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                  NoSuchMethodException e) {
             e.printStackTrace();

--- a/src/main/java/com/br/hobbie/shared/core/utils/CloneUtils.java
+++ b/src/main/java/com/br/hobbie/shared/core/utils/CloneUtils.java
@@ -1,0 +1,35 @@
+package com.br.hobbie.shared.core.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+public class CloneUtils {
+
+    public static <T> T clone(Class<T> clazz, T object) {
+        // instantiate a class without calling its constructor
+        T clone = null;
+        try {
+            var constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            clone = clazz.cast(constructor.newInstance());
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                 NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+
+        // copy all fields from object to clone
+        T finalClone = clone;
+        Arrays.stream(object.getClass()
+                        .getDeclaredFields())
+                .forEach(field -> {
+                    field.setAccessible(true);
+                    try {
+                        field.set(finalClone, field.get(object));
+                    } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                    }
+                });
+
+        return clone;
+    }
+}

--- a/src/test/java/com/br/hobbie/modules/player/domain/entities/PlayerTest.java
+++ b/src/test/java/com/br/hobbie/modules/player/domain/entities/PlayerTest.java
@@ -22,6 +22,8 @@ class PlayerTest {
     static final BigDecimal LATITUDE = BigDecimal.ONE;
     static final BigDecimal LONGITUDE = BigDecimal.TEN;
 
+    static final int CAPACITY = 10;
+
     static final Set<Tag> TAGS = Set.of(new Tag("tag1"), new Tag("tag2"));
 
     private Player player;
@@ -31,7 +33,7 @@ class PlayerTest {
     void setUp() {
         player = new Player("name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
 
-        event = new Event("name", "description", 10, DATE, START_TIME, END_TIME, LATITUDE, LONGITUDE, "thumbnail", TAGS, player);
+        event = new Event("name", "description", CAPACITY, DATE, START_TIME, END_TIME, LATITUDE, LONGITUDE, "thumbnail", TAGS, player);
     }
 
     @Test

--- a/src/test/java/com/br/hobbie/modules/player/domain/entities/PlayerTest.java
+++ b/src/test/java/com/br/hobbie/modules/player/domain/entities/PlayerTest.java
@@ -177,4 +177,79 @@ class PlayerTest {
         // THEN
         Assertions.assertTrue(result.isLeft());
     }
+
+    @Test
+    @DisplayName("Should not quit an event when player is not a participant")
+    void quitEvent_ReturnsEitherErrorWhenNotParticipant() {
+        // GIVEN - setUp
+        Player other = new Player("other name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
+        player.createEvent(event);
+
+        // WHEN
+        Either<RuntimeException, Boolean> result = other.quitEvent(event);
+
+        // THEN
+        Assertions.assertTrue(result.isLeft());
+    }
+
+    @Test
+    @DisplayName("Should be able to join an event if allow new participants, if is active and if is not admin")
+    void joinEvent_WhenSuccessFull() {
+        // GIVEN - setUp
+        Player other = new Player("other name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
+        player.createEvent(event);
+
+
+        // WHEN
+        Either<RuntimeException, Boolean> result = other.joinEvent(event);
+
+        // THEN
+        Assertions.assertTrue(result.isRight());
+    }
+
+    @Test
+    @DisplayName("Should not be able to join an event if is not active")
+    void joinEvent_ReturnsEitherErrorWhenNotActive() {
+        // GIVEN - setUp
+        Player other = new Player("other name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
+        player.createEvent(event);
+        event.close();
+
+        // WHEN
+        Either<RuntimeException, Boolean> result = other.joinEvent(event);
+
+        // THEN
+        Assertions.assertTrue(result.isLeft());
+    }
+
+    @Test
+    @DisplayName("Should not be able to join an event if is admin")
+    void joinEvent_ReturnsEitherErrorWhenAdmin() {
+        // GIVEN - setUp
+        player.createEvent(event);
+
+        // WHEN
+        Either<RuntimeException, Boolean> result = player.joinEvent(event);
+
+        // THEN
+        Assertions.assertTrue(result.isLeft());
+    }
+
+    @Test
+    @DisplayName("Should not be able to join an event if event is full")
+    void joinEvent_ReturnsEitherErrorWhenEventIsFull() {
+        // GIVEN - setUp
+        Player other = new Player("other name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
+        player.createEvent(event);
+        for (int i = 0; i < CAPACITY; i++) {
+            Player player = new Player("name" + i, "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
+            event.addParticipant(player);
+        }
+
+        // WHEN
+        Either<RuntimeException, Boolean> result = other.joinEvent(event);
+
+        // THEN
+        Assertions.assertTrue(result.isLeft());
+    }
 }

--- a/src/test/java/com/br/hobbie/modules/player/domain/entities/PlayerTest.java
+++ b/src/test/java/com/br/hobbie/modules/player/domain/entities/PlayerTest.java
@@ -1,0 +1,115 @@
+package com.br.hobbie.modules.player.domain.entities;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Set;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerTest {
+    static final LocalDate DATE = LocalDate.of(1999, 1, 1);
+    static final LocalTime START_TIME = LocalTime.of(10, 0);
+    static final LocalTime END_TIME = LocalTime.of(12, 0);
+    static final BigDecimal LATITUDE = BigDecimal.ONE;
+    static final BigDecimal LONGITUDE = BigDecimal.TEN;
+
+    static final Set<Tag> TAGS = Set.of(new Tag("tag1"), new Tag("tag2"));
+
+    private Player player;
+
+    @BeforeEach
+    void setUp() {
+        player = new Player("name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
+    }
+
+    @Test
+    @DisplayName("Should add interest to player")
+    void addInterest_WhenSuccessFull() {
+        // GIVEN
+        Tag tag = new Tag("tag");
+
+        // WHEN
+        player.addInterest(tag);
+
+        // THEN
+        Assertions.assertEquals(1, player.getInterests().size());
+        Assertions.assertEquals(tag, player.getInterests().iterator().next());
+    }
+
+    @Test
+    @DisplayName("Should not add interest to player when already exists")
+    void addInterest_WhenAlreadyExists() {
+        // GIVEN
+        Tag tag = new Tag("tag");
+        player.addInterest(tag);
+
+        // WHEN
+        player.addInterest(tag);
+
+        // THEN
+        Assertions.assertEquals(1, player.getInterests().size());
+        Assertions.assertEquals(tag, player.getInterests().iterator().next());
+    }
+
+    @Test
+    @DisplayName("Should be able to add multiple interests to player")
+    void addInterests_WhenSuccessFull() {
+        // GIVEN
+        Tag tag1 = new Tag("tag1");
+        Tag tag2 = new Tag("tag2");
+
+        // WHEN
+        player.addInterests(tag1, tag2);
+
+        // THEN
+        Assertions.assertEquals(2, player.getInterests().size());
+        Assertions.assertTrue(player.getInterests().contains(tag1));
+        Assertions.assertTrue(player.getInterests().contains(tag2));
+    }
+
+    @Test
+    @DisplayName("Should not add multiple interests to player when already exists")
+    void addInterests_WhenAlreadyExists() {
+        // GIVEN
+        Tag tag1 = new Tag("tag1");
+        Tag tag2 = new Tag("tag2");
+        player.addInterests(tag1, tag2);
+
+        // WHEN
+        player.addInterests(tag1, tag2);
+
+        // THEN
+        Assertions.assertEquals(2, player.getInterests().size());
+        Assertions.assertTrue(player.getInterests().contains(tag1));
+        Assertions.assertTrue(player.getInterests().contains(tag2));
+    }
+
+
+    // the test passes, but the player should not be able to change other players references
+    // this is a proof of concept of if player can change other players references
+    // so maybe we should change the way we are doing the relationship between player and event
+    // maybe we should create a new entity called PlayerEvent and use it to make the relationship
+    // between player and event
+
+    /**
+     * The class PlayerEvent should have the following attributes:
+     * <p>
+     * private Set<Player> players;
+     * private Set<Event> events;
+     * </p>
+     * <p>
+     * the first attribute is a set of players, which means the players that are going to the event
+     * the second attribute is a set of events, which means the events that the player is going to participate
+     */
+    @Test
+    @DisplayName("Proof of concept of if player can change other players references")
+    void pocOfIfPlayerCanChangeOtherPlayersReferences() {
+    }
+}

--- a/src/test/java/com/br/hobbie/shared/core/utils/CloneUtilsTest.java
+++ b/src/test/java/com/br/hobbie/shared/core/utils/CloneUtilsTest.java
@@ -1,0 +1,99 @@
+package com.br.hobbie.shared.core.utils;
+
+import com.br.hobbie.modules.player.domain.entities.Player;
+import com.br.hobbie.modules.player.domain.entities.Tag;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+
+class CloneUtilsTest {
+    static final BigDecimal LATITUDE = BigDecimal.ONE;
+    static final BigDecimal LONGITUDE = BigDecimal.TEN;
+
+    static final Set<Tag> TAGS = Set.of(new Tag("tag1"), new Tag("tag2"));
+
+    static final LocalDate DATE = LocalDate.of(1999, 1, 1);
+
+    static Player player;
+
+    @BeforeAll
+    static void setUp() {
+        player = new Player("name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
+    }
+
+    @Test
+    @DisplayName("Should clone an object successfully")
+    void testClone_WhenSuccessFull() {
+        // GIVEN - player
+
+        // WHEN
+        Player clone = CloneUtils.clone(Player.class, player);
+
+        // THEN
+        Assertions.assertNotNull(clone);
+        Assertions.assertEquals(player.getName(), clone.getName());
+        Assertions.assertNotEquals(player, clone);
+    }
+
+    @Test
+    @DisplayName("Should clone an object with a nested object successfully")
+    void testClone_WhenSuccessFullWithNestedObject() {
+        // GIVEN - player
+        player.addInterests(new Tag("tag1"), new Tag("tag2"));
+
+        // WHEN
+        Tag clone = CloneUtils.clone(Tag.class, player.getInterests().iterator().next());
+
+        // THEN
+
+        Assertions.assertNotNull(clone);
+        Assertions.assertEquals(player.getInterests().iterator().next().getName(), clone.getName());
+    }
+
+    @Test
+    @DisplayName("Should not to be able to clone an object without a default constructor")
+    void testClone_WhenObjectWithoutDefaultConstructor() {
+        // GIVEN
+        var unsupportedClass = new ClazzWithoutDefaultConstructor("name");
+
+        // WHEN - THEN
+        Assertions.assertThrows(RuntimeException.class, () -> CloneUtils.clone(ClazzWithoutDefaultConstructor.class, unsupportedClass));
+
+
+    }
+
+    @Test
+    @DisplayName("Should not to be able to clone an object without attributes")
+    void testClone_WhenObjectWithoutAttributes() {
+        // GIVEN
+        var unsupportedClass = new ClazzWithoutAttributes();
+
+        // WHEN - THEN
+        Assertions.assertThrows(RuntimeException.class, () -> CloneUtils.clone(ClazzWithoutAttributes.class, unsupportedClass));
+    }
+
+    class ClazzWithoutDefaultConstructor {
+        private String name;
+
+        public ClazzWithoutDefaultConstructor(String name) {
+            this.name = name;
+        }
+    }
+
+    class ClazzWithoutAttributes {
+        private String test;
+
+        public ClazzWithoutAttributes() {
+        }
+
+        @Override
+        public String toString() {
+            return "ClazzWithoutAttributes{}";
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description 📝

As initially the event entity had not yet been created, the `Player's` entity had no significant relationships for obviously reasons. So that's changed when Event entity was created, and now both classes have kind of complex relationship.

The relationship between players and events follow the same demo:


#### Event Side
- **EVERY** single Event has an admin which is kind of `composition` relationship according to [UML](https://www.ibm.com/docs/en/rsm/7.5.0?topic=diagrams-composition-association-relationships)
> ✏️  Basically that means an event cannot be instantiated without an player as admin
- Besides, an Event can have two or more participants (one of them will be the admin), so the cardinality is: _2...(capacity)_
> ✏️ Capacity is another attribute on Event class which determines the amount of players that will join the event.

#### Players Side

Taking a look from the players side, you can assume that the relationship is like that:

- Players can create an Event and when it happens, they automatically start as admin, again, that means an event **NEVER** starts empty.
- Players can participate of a lot of events, so means a new relationship again with another cardinality. For this one, will be: _0...*_ (until now, does not have limit for players join events)

### Show me the code 👨‍💻
```java
/** 
* This represents the relationship with `Player` from Event POV
**/

public class Event {
    @Id
    @GeneratedValue(strategy = GenerationType.SEQUENCE)
    private Long id;
    @Getter
    private String name;
    @Getter
    private String description;
    private int capacity;
    private LocalDate date;
    private LocalTime startTime;
    private LocalTime endTime;
    private BigDecimal latitude;
    private BigDecimal longitude;
    private String thumbnail;
    @Getter
    private boolean active = true;


    @ManyToMany
    private Set<Tag> categories = new HashSet<>();

    @OneToOne
    private Player admin;

    @OneToMany
    private Set<Player> participants = new HashSet<>();
}
``` 

```java

/** 
* This represents the relationship between Event and Player from Player POV
**/
public class Player implements Comparable<Player> {

    @ManyToMany(cascade = CascadeType.PERSIST)
    private final Set<Tag> interests = new LinkedHashSet<>();
    @Transient
    private int internalId;

    @Id
    @GeneratedValue(strategy = GenerationType.AUTO)
    private Long id;
    @Getter
    private String name;
    private String avatar;
    private BigDecimal matchLatitude;
    private BigDecimal matchLongitude;
    private LocalDate birthDate;

    @OneToOne(mappedBy = "admin")
    private Event adminEvent;

    @OneToMany
    private Set<Event> participantEvents = new LinkedHashSet<>();
}
``` 

### Important Note 🚧

This kind of relationship allow some weird and "buggies" behaviors, and i will explain the worse of them: 

- First you create a player, without events, just a raw player with respective attributes.

```java
var player = new Player("name", "avatar", BigDecimal.ONE, BigDecimal.TEN, LocalDate.of(1999, 1, 1));
``` 

- After that, you create an event and set's the player who was created above 

```java
var event = new Event("name", "description", CAPACITY, DATE, START_TIME, END_TIME, LATITUDE, LONGITUDE, "thumbnail", TAGS, player);
```

Fair enough, now your Event class has an admin, 1 participant, and is good to go. Your player entity had the `adminEvent` attribute assigned and added the following event on the attribute `participantEvents`, all done, what could be wrong?

So let's iterate on your `participantEvents` collection to see what happens

```java

for (var event : participantEvents) {
    // for each event object, you can access and get the admin player
   // the problem is that this admin can be some random player object, not necessarily the player who's accessing the method
   var admin = event.getAdmin();
   
   // at this moment you could be able to do something like this
  admin.closeEvent();
} 

```

And done, you closed an event that was not created by you, not just one, every single event you joined, this is a critical security fails, it could never happen, it has to exists a way from prevent this

### How the problem was Tackled ? 💡

So for solve this issue, i created a `CloneUtils` class, with one static method called `clone`. The purpose of this class is very simple, really not a big deal, the `clone` method receives two arguments, the class that will be cloned, and the concrete object to clone.

But the implementation is too much complex than that. For understating what this class does, i recommend to take a look on Java's [Reflection API](https://www.baeldung.com/java-reflection)

Which the method `clone` does under the hoods is: 
- grab the class constructor, change this visibility for public
> ⚠️ The constructor **MUST BE** an empty one, the default constructor with no arguments. 
- create a new instance for this class for a clone variable
- after that, grab all the fields, alter visibility as well
- iterate of all of them and assign to clone variable
- After that, returns a new clone instance of the class, keeping the original data immutable

### Show me the code 👨‍💻
```java
public class CloneUtils {

    public static <T> T clone(Class<T> clazz, T object) {
        // instantiate a class without calling its constructor
        T clone = null;
        try {
            // in this line below, i grab the class constructor
            var constructor = clazz.getDeclaredConstructor();
            // set the constructor visible
            constructor.setAccessible(true);
            // new instance of class (means another memory address)
            clone = constructor.newInstance();
        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                 NoSuchMethodException e) {
            e.printStackTrace();
        }

        // copy all fields from object to clone
        T finalClone = clone;
        Arrays.stream(object.getClass()
                        .getDeclaredFields())
                .forEach(field -> {
                    field.setAccessible(true);
                    try {
                        field.set(finalClone, field.get(object));
                    } catch (IllegalAccessException e) {
                        e.printStackTrace();
                    }
                });

        return clone;
    }
}
```

So now, for each `getSomething` that returns a reference for some other class, will return a copy of this reference, means another memory address, means Java will understand both as different, and it solves the main problem: i can do whatever i want to do with the returned reference, and will not have impact in original reference.

```java

public Player getAdmin() {
    // follows the flow explained above and returns a copy of this admin player with another memory position
    return CloneUtils.clone(Player.class, admin);
}

```

## Related Issue 📎

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR partially resolves #5 

## How Has This Been Tested? 🧪

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Obviously, all these features needed to be tested, so i added some tests cases for players methods, events and for the `CloneUtils`

### `Clone Utils`
- [x] Should clone an object successfully ✅
- [x] Should clone an object with a nested object successfully ✅
- [x] Should not to be able to clone an object without a default constructor ✅
- [x] Should not to be able to clone an object without attributes ✅

### `Player`

- [x] Should add interest to player ✅
- [x] Should not add interest to player when already exists ✅
- [x] Should be able to add multiple interests to player ✅
- [x] Should not add multiple interests to player when already exists ✅
- [x] Should create an event and set it as admin event ✅
- [x] Get admin event should return a copy object of the admin event to keep the original event immutable ✅
- [x] Should close an event if it is active ✅
- [x] Should do nothing if event is not active ✅
- [x] Should quit an event when player is not admin ✅
- [x] Should not quit an event when player is admin ✅
- [x] Should not quit an event when player is not a participant ✅
- [x] Should be able to join an event if allow new participants, if is active and if is not admin ✅
- [x] Should not be able to join an event if is not active ✅
- [x] Should not be able to join an event if is admin ✅
- [x] Should not be able to join an event if event is full ✅

## Types of changes 📝

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist ✅

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
